### PR TITLE
slightly faster l1 attention cuda kernels

### DIFF
--- a/benchmark_l1_attn.py
+++ b/benchmark_l1_attn.py
@@ -1,0 +1,52 @@
+import torch
+import l1attn_cuda
+import time
+
+def benchmark_gpu(batch_size, seq_length, num_heads, head_dim, num_runs=100):
+    device = torch.device("cuda")
+    
+    # Initialize inputs
+    q = torch.randn(batch_size, seq_length, num_heads, head_dim, device=device)
+    k = torch.randn(batch_size, seq_length, num_heads, head_dim, device=device)
+    
+    # Warm-up
+    for _ in range(10):
+        _ = l1attn_cuda.L1AttnFn.apply(q, k)
+    
+    # GPU benchmark
+    torch.cuda.synchronize()
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+    
+    start_event.record()
+    for _ in range(num_runs):
+        _ = l1attn_cuda.L1AttnFn.apply(q, k)
+    end_event.record()
+    
+    torch.cuda.synchronize()
+    gpu_time = start_event.elapsed_time(end_event) / 1000  # Convert to seconds
+    
+    return gpu_time
+
+def run_gpu_benchmarks():
+    configs = [
+        # batch_size, seq_length, num_heads, head_dim
+        (1, 128, 8, 64),
+        (1, 512, 8, 64),
+        (1, 1024, 8, 64),
+        (8, 128, 8, 64),
+        (8, 512, 8, 64),
+        (8, 1024, 8, 64),
+        (32, 1024, 8, 64),
+    ]
+    
+    print("Configuration | GPU Time (s) | Time per Run (ms)")
+    print("-" * 50)
+    
+    for batch_size, seq_length, num_heads, head_dim in configs:
+        gpu_time = benchmark_gpu(batch_size, seq_length, num_heads, head_dim)
+        time_per_run = (gpu_time * 1000) / 100  # Convert to ms
+        print(f"{batch_size}x{seq_length}x{num_heads}x{head_dim} | {gpu_time:.4f} | {time_per_run:.2f}")
+
+if __name__ == "__main__":
+    run_gpu_benchmarks()


### PR DESCRIPTION
I have made the following changes:

1. Included shared memory usage to cache query and key vectors and hence reduced global memory accesses. This is done in the forward pass of `l1attn_cuda_forward_kernelX`
```
__shared__ scalar_t q_shared[32];
__shared__ scalar_t k_shared[32];
```

Also modified the mail computation loop to utilise the shared memory:

```
if(o < width) {
    q_shared[tix] = q[b][t][h][o];
    k_shared[tix] = k[b][s][h][o];
    f += abs(q_shared[tix] - k_shared[tix]); 
}
```

2. In the forwad pass of the `l1attn_cuda_forward_kernel16` kernel,

the memory loading pattern is modified:

```
for (int i = 0; i < 2; i++) {
    qc[cu + i*8][cw] = q[b][h][t + i*8][cw];
    kc[cu + i*8][cw] = k[b][h][s + i*8][cw];
}
```

3. In the backward pass of the ` l1attn_cuda_backward_kernel` I added shared memory for q and k:

```
__shared__ scalar_t q_shared[32];
__shared__ scalar_t k_shared[32];
```

and then, modified the computation to use shared memory:

```
q_shared[tix] = q[b][w][h][r];
scalar_t qq = q_shared[tix];

```


4. In the backward pass of the ` l1attn_cuda_backward_kernel16` I modified memory loading for better coalescing:

```
for (int i = 0; i < 2; i++) {
    qc[cr + i*8][cw] = q[b][h][t + i*8][cw];
    kc[cr + i*8][cw] = k[b][h][s + i*8][cw];
}

```
---

After making these changes, I wanted to test the improvements in speed, so used two identical cloud VMs running the following specs:


